### PR TITLE
txt format will use default icon, because CMakeLists.txt should use cmake icon

### DIFF
--- a/src/nl/hannahsten/texifyidea/TexifyIcons.kt
+++ b/src/nl/hannahsten/texifyidea/TexifyIcons.kt
@@ -290,7 +290,7 @@ object TexifyIcons {
             "cls" -> CLASS_FILE
             "dtx" -> DOCUMENTED_LATEX_SOURCE
             "sty" -> STYLE_FILE
-            "txt" -> TEXT_FILE
+//            "txt" -> TEXT_FILE
             "tikz" -> TIKZ_FILE
             "log" -> TEXT_FILE
             "pdf" -> PDF_FILE


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #

#### Summary of additions and changes

* 

#### How to test this pull request

```latex

```

- [ ] Updated the documentation, or no update necessary
- [ ] Added tests, or no tests necessary